### PR TITLE
Bug/multiprocessing windows

### DIFF
--- a/eepackages/multiprocessing/download_image.py
+++ b/eepackages/multiprocessing/download_image.py
@@ -46,8 +46,6 @@ def download_image(
     
     image_list: i_ee.List = i_ee.deserializer.fromJSON(serialized_image_list)
 
-    plogger.info(type(image_list))
-
     img: i_ee.Image = i_ee.Image(image_list.get(index))
     url: str = image_download_method(img, download_kwargs)
     r: requests.Response = requests.get(url, stream=True)

--- a/eepackages/multiprocessing/download_image.py
+++ b/eepackages/multiprocessing/download_image.py
@@ -1,0 +1,94 @@
+import logging
+from pathlib import Path
+import requests
+import shutil
+from typing import Any, Callable, Dict, Optional
+
+from pathos import logger
+from pathos.core import getpid
+from retry import retry
+
+@retry(tries=10, delay=5, backoff=10)
+def download_image(
+    i_ee,
+    index: int,
+    image_download_method: Callable,
+    serialized_image_list: Dict[str, Any],
+    name_prefix: str,
+    out_dir: Optional[Path],
+    download_kwargs: Optional[Dict[str, Any]]
+) -> None:
+    """
+    Hidden function to be used with download_image_collection. As we want compatibility with
+    windows, we need to use dill to pickle the initialized earthengine module. Pathos uses
+    dill pickle data uses to start new processes with its multiprocessing pool, while the python
+    multiprocessing module uses pickle, which cannot pickle module objects.
+    """
+
+    if not out_dir:
+        out_dir: Path = Path.cwd() / "output"
+    if not download_kwargs:
+        download_kwargs: Dict[str, str] = {}
+
+    pid = getpid()
+    log_file: Path = out_dir / "logging" / f"{pid}.log"
+    fh = logging.FileHandler(log_file)
+    fh.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
+    fh.setFormatter(formatter)
+
+    plogger = logger(level=logging.DEBUG, handler=fh)
+
+    ee_api_url: str = i_ee.data._cloud_api_base_url
+    ee_hv_url: str = "https://earthengine-highvolume.googleapis.com"
+    if ee_api_url is not ee_hv_url:
+        i_ee.Initialize(opt_url=ee_hv_url)
+    
+    image_list: i_ee.List = i_ee.deserializer.fromJSON(serialized_image_list)
+
+    plogger.info(type(image_list))
+
+    img: i_ee.Image = i_ee.Image(image_list.get(index))
+    url: str = image_download_method(img, download_kwargs)
+    r: requests.Response = requests.get(url, stream=True)
+
+    # File format chain
+    format: Optional[str] = download_kwargs.get("format")
+    if format:
+        if format == "GEO_TIFF":
+            extention: str = ".tif"
+        elif format == "NPY":
+            extention: str = ".npy"
+        elif format == "PNG":
+            extention: str = ".png"
+        elif format == "JPG":
+            extention: str = ".jpg"
+        else:
+            extention: str = ".tif.zip"
+    elif image_download_method == i_ee.Image.getDownloadURL:
+        extention: str = ".tif.zip"
+    elif image_download_method == i_ee.Image.getThumbURL:
+        extention: str = ".png"
+    else:
+        raise RuntimeError(
+            f"image download method {image_download_method} unknown.")
+
+    # Image naming chain
+    img_props: Dict[str, Any] = img.getInfo()['properties']
+    t0: Optional[int] = img_props.get("system:time_start")
+    img_index: Optional[int] = img_props.get("system:index")
+    if t0:
+        file_id: str = t0
+    elif img_index:
+        file_id: str = img_index
+    else:
+        file_id: str = index
+
+    # File name
+    filename: Path = out_dir / f"{name_prefix}{file_id}{extention}"
+
+    with open(filename, 'wb') as out_file:
+        shutil.copyfileobj(r.raw, out_file)
+    
+    plogger.info(f"Done: {index}")
+    plogger.removeHandler(fh)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 earthengine-api>=0.1.282
+pathos>=0.2.8
 retry>=0.9.2

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
 
     install_requires=[
         "earthengine-api>=0.1.284",
+        "pathos>=0.2.8",
         "retry>=0.9.2"
     ],
 


### PR DESCRIPTION
Multiprocessing module did not work when using the dynamically generated `ee` library on windows, as Windows cannot use the `fork` process spawner.

Therefore had to switch pickler (by using `pathos` multiprocessing fork) and encode the earthengine class before sending it to the new process.