### PR TITLE
fixed s2MergeByTime bug, backwards compatible

### DIFF
--- a/eepackages/applications/bathymetry.py
+++ b/eepackages/applications/bathymetry.py
@@ -30,6 +30,7 @@ class Bathymetry(object):
         pansharpen: bool = False,
         skip_neighborhood_search: bool = False,
         bounds_buffer: int = 10000,
+        s2merge: Optional[str] = None,
     ) -> ee.Image:
         images: ee.ImageCollection = self.get_images(
             bounds=bounds,
@@ -38,7 +39,8 @@ class Bathymetry(object):
             filter_masked=filter_masked,
             scale=scale,
             missions=missions,
-            cloud_frequency_threshold_delta=cloud_frequency_threshold_data
+            cloud_frequency_threshold_delta=cloud_frequency_threshold_data,
+            s2merge=s2merge
         )
         # save loaded images in class as raw_images
         self._raw_images = images
@@ -377,7 +379,8 @@ class Bathymetry(object):
         missions: List[str],
         filter_masked_fraction: Optional[float] = None,
         cloud_frequency_threshold_delta: float = 0.15,
-        filter: Optional[ee.Filter] = None
+        filter: Optional[ee.Filter] = None,
+        s2merge: Optional[str] = None,
     ) -> ee.ImageCollection:
         date_filter: ee.Filter = ee.Filter.date(start, stop)
         if filter:
@@ -391,7 +394,8 @@ class Bathymetry(object):
             "filterMasked": filter_masked,
             "filterMaskedFraction": filter_masked_fraction,
             "scale": ee.Number(scale).multiply(10),  # why *10?
-            "resample": True
+            "resample": True,
+            "s2TimeMerger": s2merge,
         }
 
         images: ee.ImageCollection = assets.getImages(bounds, options_get_images)

--- a/eepackages/assets.py
+++ b/eepackages/assets.py
@@ -46,7 +46,12 @@ def getImages(g, options):
     
     if options and 's2MergeByTime' in options:
         s2MergeByTime = options['s2MergeByTime']
-    
+
+    s2TimeMerger = False
+
+    if options and 's2TimeMerger' in options:
+        s2TimeMerger = options['s2TimeMerger']
+
     cloudMask = False
     
     if options and 'cloudMask' in options:
@@ -200,7 +205,7 @@ def getImages(g, options):
 
     # merge by time (remove duplicates)
     if s2MergeByTime:
-        s2 = mosaicByTime(s2)
+        s2 = mosaicByTime(s2, s2TimeMerger)
 
     def f2(i):
         return (i
@@ -309,8 +314,17 @@ def getImages(g, options):
 #  * 
 #  * This function mosaics images by time.
 #  */
-def mosaicByTime(images):
-    TIME_FIELD = 'system:time_start'
+def mosaicByTime(images, *args):
+    if 'dd' in args: # for rounding up until days
+        def f(i):
+            dateField = ee.Date(i.get('system:time_start')).format('YYYYMMdd') #hhmmss.SSS rounded to a minute
+            return i.set({'dateField':dateField})
+
+        images = images.map(f)
+        
+        TIME_FIELD = 'dateField'
+    else:
+        TIME_FIELD = 'system:time_start'
 
     distinct = images.distinct([TIME_FIELD])
 


### PR DESCRIPTION
added functionality (backwards compatible) to filter duplicates using s2merge = 'dd' in the complete compute_inverse_depth function or s2TimeMerger = 'dd' in the getImages subfunction. Note that dd stands for the capping on days in the mosaicbyTime function

@Jaapel @gena, please provide feedback on whether the coding (formatting and quality) is in line with the repository and whether you agree with the changes. I checked the changes locally before opening this pull request. There were no crashes and everything worked fine on a test case in Taiwan. Original code did not changed as it was added using **args (backwards compatible).  